### PR TITLE
Support recursive descent on directories when formatting scripts

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -3,6 +3,7 @@
 import sys
 
 import test_formatting
+import test_dir_recursion
 import test_pylint
 
 if __name__ == '__main__':
@@ -10,4 +11,6 @@ if __name__ == '__main__':
     # all succeed.
     sys.exit(not all((
         test_formatting.test(),
-        test_pylint.test())))
+        test_dir_recursion.test(),
+        test_pylint.test(),
+        )))

--- a/tests/test_dir_recursion.py
+++ b/tests/test_dir_recursion.py
@@ -1,0 +1,111 @@
+#! /usr/bin/env python
+import argparse
+import io
+import os
+import shutil
+import sys
+import unittest
+import unittest.mock
+
+from os.path import join
+
+TESTS = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.normpath(join(TESTS, '..'))
+DATA = os.path.normpath(join(TESTS, 'data'))
+
+# Prepend the tree's root folder to the module searchpath so we find zeekscript
+# via it. This allows tests to run without package installation. (We do need a
+# package build though, so the .so bindings library gets created.)
+sys.path.insert(0, ROOT)
+
+import zeekscript
+
+class TestRecursion(unittest.TestCase):
+
+    def setUp(self):
+        # Set up a small directory tree with Zeek scripts and other files
+        shutil.rmtree('a', ignore_errors=True)
+        os.makedirs(join('a', 'b', 'c'))
+
+        shutil.copy(join(DATA, 'test1.zeek'), join('a', 'test1.zeek'))
+        shutil.copy(join(DATA, 'test1.zeek'), join('a', 'test2.zeek'))
+        shutil.copy(join(DATA, 'test1.zeek'), join('a', 'b', 'test3.txt'))
+        shutil.copy(join(DATA, 'test1.zeek'), join('a', 'b', 'test4.zeek'))
+        shutil.copy(join(DATA, 'test1.zeek'), join('a', 'b', 'c', 'test5.zeek'))
+
+    def tearDown(self):
+        shutil.rmtree('a', ignore_errors=True)
+
+    def _have_same_content(self, file1, file2):
+        with open(file1) as hdl1, open(file2) as hdl2:
+            return hdl1.read() == hdl2.read()
+
+    @unittest.skipIf(sys.platform == 'win32', 'Not yet supported')
+    def test_recursive_formatting(self):
+        parser = argparse.ArgumentParser()
+        zeekscript.add_format_cmd(parser)
+        args = parser.parse_args(['-i', '-r', 'a'])
+
+        # Python < 3.10 does not yet support parentheses around these:
+        with unittest.mock.patch('sys.stdout', new=io.StringIO()) as out, \
+             unittest.mock.patch('sys.stderr', new=io.StringIO()) as err:
+            ret = args.run_cmd(args)
+            self.assertEqual(ret, 0)
+            self.assertEqual(out.getvalue(), '4 files processed successfully\n')
+
+        self.assertTrue(self._have_same_content(
+            join(DATA, 'test1.zeek.out'), join('a', 'test1.zeek')))
+        self.assertTrue(self._have_same_content(
+            join(DATA, 'test1.zeek.out'), join('a', 'test2.zeek')))
+        self.assertFalse(self._have_same_content(
+            join(DATA, 'test1.zeek.out'), join('a', 'b', 'test3.txt')))
+        self.assertTrue(self._have_same_content(
+            join(DATA, 'test1.zeek.out'), join('a', 'b', 'test4.zeek')))
+        self.assertTrue(self._have_same_content(
+            join(DATA, 'test1.zeek.out'), join('a', 'b', 'c', 'test5.zeek')))
+
+    def test_recurse_inplace(self):
+        parser = argparse.ArgumentParser()
+        zeekscript.add_format_cmd(parser)
+        args = parser.parse_args(['-ir'])
+
+        with unittest.mock.patch('sys.stdout', new=io.StringIO()) as out, \
+             unittest.mock.patch('sys.stderr', new=io.StringIO()) as err:
+            ret = args.run_cmd(args)
+            self.assertEqual(ret, 0)
+            self.assertEqual(err.getvalue(), 'warning: cannot use --inplace when reading from stdin, skipping it\n')
+
+    def test_dir_without_recurse(self):
+        parser = argparse.ArgumentParser()
+        zeekscript.add_format_cmd(parser)
+        args = parser.parse_args(['-i', 'a'])
+
+        with unittest.mock.patch('sys.stdout', new=io.StringIO()) as out, \
+             unittest.mock.patch('sys.stderr', new=io.StringIO()) as err:
+            ret = args.run_cmd(args)
+            self.assertEqual(ret, 0)
+            self.assertEqual(err.getvalue(), 'warning: "a" is a directory but --recursive not set, skipping it\n')
+
+    def test_recurse_without_inplace(self):
+        parser = argparse.ArgumentParser()
+        zeekscript.add_format_cmd(parser)
+        args = parser.parse_args(['-r', 'a'])
+
+        with unittest.mock.patch('sys.stdout', new=io.StringIO()) as out, \
+             unittest.mock.patch('sys.stderr', new=io.StringIO()) as err:
+            ret = args.run_cmd(args)
+            self.assertEqual(ret, 1)
+            self.assertEqual(err.getvalue(), 'error: recursive file processing requires --inline\n')
+
+
+def test():
+    """Entry point for testing this module.
+
+    Returns True if successful, False otherwise.
+    """
+    res = unittest.main(sys.modules[__name__], verbosity=0, exit=False)
+    # This is how unittest.main() implements the exit code itself:
+    return res.result.wasSuccessful()
+
+if __name__ == '__main__':
+    sys.exit(not test())

--- a/zeekscript/formatter.py
+++ b/zeekscript/formatter.py
@@ -165,7 +165,7 @@ class Formatter:
             self._format_child(hints=hints | first_hints | Hint.NO_LB_AFTER)
 
             # Inner elements: general hinting; avoid line breaks
-            for idx in range(num-2):
+            for _ in range(num-2):
                 self._format_child(hints=hints | Hint.NO_LB_AFTER)
 
             # Last element: general hinting only.
@@ -640,9 +640,6 @@ class CaptureListFormatter(Formatter):
 
 
 class StmtFormatter(TypedInitializerFormatter):
-    def __init__(self, script, node, ostream, indent=0, hints=None):
-        super().__init__(script, node, ostream, indent, hints)
-
     def _child_is_curly_stmt(self):
         """Looks ahead to see if the upcoming statement is { ... }.
         This decides surrounding whitespace in some situations below.

--- a/zeekscript/output.py
+++ b/zeekscript/output.py
@@ -123,9 +123,6 @@ class OutputStream:
             while tbd and not tbd[0].data.strip():
                 tbd_len -= len(tbd.pop(0).data)
 
-        def all_blank(tbd):
-            return all([len(out.data.strip()) == 0 for out in tbd])
-
         # Count number of non-whitespace items on the line. This helps with some
         # linebreak heuristics below.
         for out in self._linebuffer:

--- a/zeekscript/script.py
+++ b/zeekscript/script.py
@@ -108,7 +108,7 @@ class Script:
                 msg = 'missing grammar node "{}" on line {}, col {}'.format(
                     node.type, node.start_point[0], node.start_point[1])
             elif node.has_error and (not node.children or
-                                     not any([kid.has_error for kid in node.children])):
+                                     not any((kid.has_error for kid in node.children))):
                 msg = 'grammar node "{}" has error on line {}, col {}'.format(
                     node.type, node.start_point[0], node.start_point[1])
             else:


### PR DESCRIPTION
This adds the --recursive|-r flag to zeek-format and "zeek-script format". When
set, the commands process directory names recursively, formatting any *.zeek
file in them. This requires --inplace and will error out when not given.

In the absence of --recursive, directories are now properly recognized, warned
about, and skipped.

Includes testcases.

Resolves #1
Resolves #2