### PR TITLE
Fix version handling

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,6 @@ exclude tree-sitter-zeek/src/.git
 
 # In a source distribution, never include any build bindings
 exclude zeekscript/*.so
+
+# setup.py needs the VERSION file for the build
+include VERSION

--- a/zeek-format
+++ b/zeek-format
@@ -22,6 +22,8 @@ import zeekscript
 
 def create_parser():
     parser = argparse.ArgumentParser(description='A Zeek script formatter')
+
+    zeekscript.add_version_arg(parser)
     zeekscript.add_format_cmd(parser)
 
     if 'argcomplete' in sys.modules:
@@ -33,6 +35,10 @@ def create_parser():
 def main():
     parser = create_parser()
     args = parser.parse_args()
+
+    if args.version:
+        print(zeekscript.__version__)
+        return 0
 
     try:
         return args.run_cmd(args)

--- a/zeek-script
+++ b/zeek-script
@@ -22,6 +22,9 @@ import zeekscript
 
 def create_parser():
     parser = argparse.ArgumentParser(description='A Zeek script analyzer')
+
+    zeekscript.add_version_arg(parser)
+
     command_parser = parser.add_subparsers(
         title='commands', dest='command',
         help='See `%(prog)s <command> -h` for per-command usage info.')
@@ -46,6 +49,10 @@ def create_parser():
 def main():
     parser = create_parser()
     args = parser.parse_args()
+
+    if args.version:
+        print(zeekscript.__version__)
+        return 0
 
     if not args.command:
         zeekscript.print_error('error: please provide a command to execute. See --help.')

--- a/zeekscript/cli.py
+++ b/zeekscript/cli.py
@@ -91,6 +91,11 @@ def cmd_parse(args):
     return 0
 
 
+def add_version_arg(parser):
+    parser.add_argument(
+        '--version', '-v', action='store_true', help='show version and exit')
+
+
 def add_format_cmd(parser):
     """This adds a Zeek script formatting CLI interface to the given argparse
     parser. It registers the cmd_format() callback as the parser's run_cmd


### PR DESCRIPTION
The VERSION file was missing from the sdist, breaking builds triggered when a `pip install` leads to the source distribution being downloaded.

Add `--version`/`-v` to the commands, while we're at it.