### PR TITLE
Modernize pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [project]
+name = "zeekscript"
+
+[build-system]
 requires = [ "setuptools", "wheel" ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
PEP 621's enforcement has changed and "pip install" now blows up on modern installations due to pyproject.toml's content. This should fix it.