### PR TITLE
Better formatting in the presence of parser errors

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.3.1
         env:
+          # We currently skip all PyPy builds on Windows due to hard
+          # exits of the Python interpreter with some input trees.
+          CIBW_SKIP: pp*-win*
           CIBW_TEST_REQUIRES: pylint
           CIBW_TEST_COMMAND: python {project}/tests/test_all.py
           CIBW_TEST_COMMAND_WINDOWS: python.exe {project}/tests/test_all.py

--- a/tests/data/test2.zeek
+++ b/tests/data/test2.zeek
@@ -1,4 +1,0 @@
-event zeek_init() {
-	# A syntax error that trips up parsing:
-	foo)();
-}

--- a/tests/test_dir_recursion.py
+++ b/tests/test_dir_recursion.py
@@ -54,7 +54,7 @@ class TestRecursion(unittest.TestCase):
              unittest.mock.patch('sys.stderr', new=io.StringIO()) as err:
             ret = args.run_cmd(args)
             self.assertEqual(ret, 0)
-            self.assertEqual(out.getvalue(), '4 files processed successfully\n')
+            self.assertEqual(out.getvalue(), '4 files processed, 0 errors\n')
 
         self.assertEqualContent(
             join(DATA, 'test1.zeek.out'), join('a', 'test1.zeek'))
@@ -99,7 +99,7 @@ class TestRecursion(unittest.TestCase):
              unittest.mock.patch('sys.stderr', new=io.StringIO()) as err:
             ret = args.run_cmd(args)
             self.assertEqual(ret, 1)
-            self.assertEqual(err.getvalue(), 'error: recursive file processing requires --inline\n')
+            self.assertEqual(err.getvalue(), 'error: recursive file processing requires --inplace\n')
 
 
 def test():

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -18,21 +18,36 @@ import zeekscript
 
 class TestFormatting(unittest.TestCase):
 
-    def _get_formatted_and_baseline(self, filename):
-        script = zeekscript.Script(os.path.join(DATA, filename))
-        script.parse()
+    def _get_input_and_baseline(self, filename):
+        with open(os.path.join(DATA, filename), 'rb') as hdl:
+            input = hdl.read()
+
+        with open(os.path.join(DATA, filename + '.out'), 'rb') as hdl:
+            output = hdl.read()
+
+        return input, output
+
+    def _format(self, content):
+        script = zeekscript.Script(io.BytesIO(content))
+
+        self.assertTrue(script.parse())
+        self.assertFalse(script.has_error())
 
         buf = io.BytesIO()
         script.format(buf)
 
-        with open(os.path.join(DATA, filename + '.out'), 'rb') as hdl:
-            result_wanted = hdl.read()
-        result_is = buf.getvalue()
-        return result_wanted, result_is
+        return buf.getvalue()
 
     def test_file_formatting(self):
-        result_wanted, result_is = self._get_formatted_and_baseline('test1.zeek')
-        self.assertEqual(result_wanted, result_is)
+        input, baseline = self._get_input_and_baseline('test1.zeek')
+
+        # Format the input data and compare to baseline:
+        result1 = self._format(input)
+        self.assertEqual(baseline, result1)
+
+        # Format the result again. There should be no change.
+        result2 = self._format(result1)
+        self.assertEqual(baseline, result2)
 
     def test_parse_error(self):
         script = zeekscript.Script(os.path.join(DATA, 'test2.zeek'))

--- a/zeekscript/cli.py
+++ b/zeekscript/cli.py
@@ -68,6 +68,11 @@ def cmd_format(args):
         try:
             if not script.parse():
                 ret = 1
+                _, _, msg = script.get_error()
+                if len(scripts) > 1:
+                    print_error('{}: {}'.format(fname, msg))
+                else:
+                    print_error(msg)
         except Error as err:
             print_error('parsing error: ' + str(err))
             do_write(script.source)

--- a/zeekscript/formatter.py
+++ b/zeekscript/formatter.py
@@ -158,20 +158,22 @@ class Formatter:
 
         if num <= 0:
             return
-        elif num == 1:
+
+        if num == 1:
             # Single element: general and first-element hinting
             self._format_child(hints=hints | first_hints)
-        else:
-            # First element of multiple: general hinting; first-element hinting;
-            # avoid line breaks after the element.
-            self._format_child(hints=hints | first_hints | Hint.NO_LB_AFTER)
+            return
 
-            # Inner elements: general hinting; avoid line breaks
-            for _ in range(num-2):
-                self._format_child(hints=hints | Hint.NO_LB_AFTER)
+        # First element of multiple: general hinting; first-element hinting;
+        # avoid line breaks after the element.
+        self._format_child(hints=hints | first_hints | Hint.NO_LB_AFTER)
 
-            # Last element: general hinting only.
-            self._format_child(hints=hints)
+        # Inner elements: general hinting; avoid line breaks
+        for _ in range(num-2):
+            self._format_child(hints=hints | Hint.NO_LB_AFTER)
+
+        # Last element: general hinting only.
+        self._format_child(hints=hints)
 
     def _format_children(self, sep=None):
         """Format all children of the node.

--- a/zeekscript/formatter.py
+++ b/zeekscript/formatter.py
@@ -105,6 +105,11 @@ class Formatter:
         node.formatter = self
 
     def format(self):
+        """Default formatting for a tree node
+
+        This simply writes out children as per their own formatting, and writes
+        out tokens directly.
+        """
         if self.node.children:
             self._format_children()
         else:
@@ -295,9 +300,9 @@ class Formatter:
     @staticmethod
     def lookup(node):
         """Formatter lookup for a zeekscript.Node, based on its type information."""
-        # If we're looking up a token node, always use a dummy formatter.
-        # This ensures that we don't confuse a node.type of the same name,
-        # e.g. a variable called 'decl'.
+        # If we're looking up a token node, always use the fallback formatter,
+        # which writes it out directly.  This ensures that we don't confuse a
+        # node.type of the same name, e.g. a variable called 'decl'.
         if not node.is_named:
             return Formatter
         return MAP.get(node.type)

--- a/zeekscript/formatter.py
+++ b/zeekscript/formatter.py
@@ -130,18 +130,21 @@ class Formatter:
                            hints=hints)
         formatter.format()
 
-    def _format_child(self, node=None, indent=False, hints=None):
-        if node is None:
-            node = self._next_child()
+    def _format_child(self, child=None, indent=False, hints=None):
+        if child is None:
+            child = self._next_child()
 
-        for child in node.prev_cst_siblings:
-            self._format_child_impl(child, indent)
+        # XXX Pretty subtle that a child's CST nodes get handled in the
+        # parent. Might have to refactor in the future.
 
-        # The hints apply to AST (not CST) nodes
-        self._format_child_impl(node, indent, hints)
+        for node in child.prev_cst_siblings:
+            self._format_child_impl(node, indent)
 
-        for child in node.next_cst_siblings:
-            self._format_child_impl(child, indent)
+        # The hints apply to AST (not CST) nodes, so now:
+        self._format_child_impl(child, indent, hints)
+
+        for node in child.next_cst_siblings:
+            self._format_child_impl(node, indent)
 
     def _format_child_range(self, num, hints=None, first_hints=None):
         """Format a given number of children of the node.
@@ -360,7 +363,7 @@ class ErrorFormatter(Formatter):
                     content = self.script.get_content(start, node_start)
                     self._write(content, raw=True)
 
-                self._format_child(node=node)
+                self._format_child(child=node)
                 start = node_end
 
         if start < end:

--- a/zeekscript/node.py
+++ b/zeekscript/node.py
@@ -49,7 +49,13 @@ class Node:
         # Consider name() or token() below instead of accessing this directly
         self.type = None
 
-        # Additions over the TS node members below:
+        # ---- Additions over the TS node members below ------------------------
+
+        # A variant of self.children, consisting only of the non-ERROR nodes.
+        # This subset is safe to navigate with expectation of node types
+        # (e.g. "the first node should be a type, the second a ':", etc), since
+        # it's free of CST and error nodes.
+        self.nonerr_children = []
 
         # A zeekscript.Formatter attached with this node. Formatters
         # set this field as they get instantiated.
@@ -92,6 +98,11 @@ class Node:
         #
         self.prev_cst_siblings = []
         self.next_cst_siblings = []
+
+        # Two arrays for AST nodes that represent any directly
+        # preceeding/succeeding ERROR nodes.
+        self.prev_error_siblings = []
+        self.next_error_siblings = []
 
     def name(self):
         """Returns the type of a named node.

--- a/zeekscript/node.py
+++ b/zeekscript/node.py
@@ -28,11 +28,22 @@ class Node:
         self.next_sibling = None
 
         self.start_byte = 0
-        self.end_byte = 0
+        self.end_byte = 0 # The first byte _after_ this node's content
         self.start_point = (0, 0)
         self.end_point = (0, 0)
+
+        # This terminology stems from TreeSitter and means that a node is typed,
+        # i.e., the root of a grammar rule. It is not a token.
         self.is_named = False
+
+        # In some cases TreeSitter can infer that a node is simply missing (such
+        # as a trailing semicolon). Implies has_error, but does not lead to an
+        # ERROR node higher up.
         self.is_missing = False
+
+        # This bit indicates whether there's a parser problem somewhere below
+        # this node. This problem can be of various forms, including parse
+        # errors (node type "ERROR") or missing nodes. Any others?
         self.has_error = False
 
         # Consider name() or token() below instead of accessing this directly
@@ -63,21 +74,21 @@ class Node:
         # succeeding this node. These lists are in tree-order: if a tree node's
         # sequence of children is ...
         #
-        #   <minor comment>  (CST)
+        #   <minor comment1> (CST)
         #   <nl>             (CST)
-        #   <minor comment>  (CST)
+        #   <minor comment2> (CST)
         #   <nl>             (CST)
         #   <expr>           (AST)
-        #   <minor_comment>  (CST)
+        #   <minor_comment3> (CST)
         #   <nl>             (CST)
         #
         # ... then the members of prev_cst_siblings are ...
         #
-        #   [ <minor comment>, <nl>, <minor comment>, <nl>]
+        #   [ <minor comment1>, <nl>, <minor comment2>, <nl>]
         #
         # ... and those of next_cst_siblings are:
         #
-        # [ <minor comment>, <nl>]
+        # [ <minor comment3>, <nl>]
         #
         self.prev_cst_siblings = []
         self.next_cst_siblings = []

--- a/zeekscript/output.py
+++ b/zeekscript/output.py
@@ -71,7 +71,14 @@ class OutputStream:
     def use_space_align(self, enable):
         self._use_space_align = enable
 
-    def write(self, data, formatter):
+    def write(self, data, formatter, raw=False):
+        if raw:
+            self._flush_line()
+            self._write(data)
+            # Sync column count as per last line content in raw data:
+            self._col = len(data.split(Formatter.NL)[-1])
+            return
+
         # For troubleshooting received hinting
         # print_error('XXX "%s" %s' % (data, formatter.hints))
 

--- a/zeekscript/script.py
+++ b/zeekscript/script.py
@@ -71,8 +71,10 @@ class Script:
         and for subtler errors their has_error bit is set. This function
         reports True when any of these conditions hold.
         """
+        assert self.root is not None, 'call Script.parse() before Script.has_error()'
+
         # Could cache this result while we don't support tree modifications
-        for node, _ in self._visit(self.ts_tree.root_node):
+        for node, _ in self._visit(self.root):
             if node.type == 'ERROR' or node.is_missing or node.has_error:
                 return True
 
@@ -93,9 +95,11 @@ class Script:
 
         - An error message string that tries to explain the problem.
         """
+        assert self.root is not None, 'call Script.parse() before Script.get_error()'
+
         line, lineno, msg = None, None, None
 
-        for node, _ in self._visit(self.ts_tree.root_node):
+        for node, _ in self._visit(self.root):
             snippet = self.source[node.start_byte:node.end_byte]
             if len(snippet) > 50:
                 snippet = snippet[:50] + b'[...]'
@@ -130,6 +134,7 @@ class Script:
         2, etc.
         """
         assert self.root is not None, 'call Script.parse() before Script.traverse()'
+
         for node, nesting in self._visit(self.root, include_cst):
             yield node, nesting
 
@@ -138,6 +143,8 @@ class Script:
 
         This simplifies accessing specific text chunks in the source.
         """
+        assert self.root is not None, 'call Script.parse() before accessing content'
+
         return self.source.__getitem__(key)
 
     def get_content(self, start_byte=None, end_byte=None):
@@ -147,6 +154,8 @@ class Script:
         provided, are numerical byte offsets in the script, behaving as usual
         indices in slice notation.
         """
+        assert self.root is not None, 'call Script.parse() before Script.get_content()'
+
         return self.source[start_byte:end_byte]
 
     def format(self, output=None, enable_linebreaks=True):


### PR DESCRIPTION
This is a big changeset that was quite tricky to put together.

Part of the problems reported in #11 was easily fixed for reasons like lacking output flushing, but when playing more with parser errors I realized that the fact that error nodes can appear anywhere in the tree fundamentally collides with the way formatters expect their node subtrees to be laid out. For example, if the grammar says that a Foo consists of a node Bar followed by a Baz, and the parser successfully produces a Foo, it's reasonable to expect the first node to be a Bar and the second a Baz — but when error nodes can instead pop up anywhere, that's not the case.

So to work around this we now handle error nodes via a dedicated formatter that tries to preserve the existing content, unless any child nodes of the error node got parsed fully and thus permit formatting. We also add extra structure to zeekscript's internal parse tree (that it builds from TreeSitter's) to "hide" error nodes. The approach resembles how we we handle comments, but this is more subtle since error nodes can potentially make up large chunks of the script. We now group error nodes with surrounding siblings, and offer an "indexing-safe" alternative child list for indexing/navigating into. This allows the formatters to remain unchanged. See commits for details.

Another challenge when formatting with errors is for the formatting to "converge": ideally you'd like the formatting to settle, so that repeated formatting doesn't keep bouncing around whitespace or — worse — runs content together so existing errors grow worse. The testsuite now verifies that repeated formatting does not change content.

This also changes the exit code and stderr behavior: parser errors lead to exit with 1, plus the first error in the script gets reported to stderr.

There are technically still possibilities for content to get swallowed by reformatting, namely when a particular formatter doesn't "use up" all the child nodes it has available, but that's a different kind of error.

Resolves #11.