### PR TITLE
Add ability to surpress output for parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ zeekscript/zeek-language.so
 zeekscript/zeek-language.exp
 zeekscript/zeek-language.lib
 __pycache__
+.idea/


### PR DESCRIPTION
Add `--quiet, -q' flag, so that if you want you can call parse and just get success or failure.

This will be better if calling from something like `pre-commit` git hooks to make sure you can parse all zeek scripts.