### PR TITLE
Pull in tree-sitter-zeek bump to fix handling of "bare" minor comments

### DIFF
--- a/tests/data/test1.zeek
+++ b/tests/data/test1.zeek
@@ -23,6 +23,9 @@ module  Test;
 	};
 
 	# An enum, with assignments, on multiple lines, which should remain.
+	# Also, we separate via an empty minor comment, which used to
+	# trigger zeek/tree-sitter-zeek#9:
+	#
 	type AssigedEnum: enum {
 	  FOO=1,
 	  BAR=10,

--- a/tests/data/test1.zeek.out
+++ b/tests/data/test1.zeek.out
@@ -23,6 +23,9 @@ export {
 	};
 
 	# An enum, with assignments, on multiple lines, which should remain.
+	# Also, we separate via an empty minor comment, which used to
+	# trigger zeek/tree-sitter-zeek#9:
+	#
 	type AssigedEnum: enum { FOO = 1, BAR = 10, };
 
 	# Another one that we put on one line. That should also remain


### PR DESCRIPTION
This also expands the general formatting test by including the construct that triggered zeek/tree-sitter-zeek#9.