### PR TITLE
Fix formatting of index slices

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15, macos-11]
+        os: [ubuntu-20.04, windows-2019, macos-11, macos-12]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -50,6 +50,23 @@ class TestFormatting(unittest.TestCase):
         result2 = self._format(result1)
         self.assertEqual(baseline, result2)
 
+    def test_index_slice(self):
+        # Use compact layout if neither side is a constant or id.
+        self.assertEqual(self._format(b"xs[  0   :1  ];").rstrip(), b"xs[0:1];")
+
+        # # If either side is unspecified do not use use compact layout, but do
+        # not add additional whitespace if both sides are omitted.
+        self.assertEqual(self._format(b"xs[  0   :  ];").rstrip(), b"xs[0:];")
+        self.assertEqual(self._format(b"xs[  : 1 ];").rstrip(), b"xs[:1];")
+        self.assertEqual(self._format(b"data[1-1:];").rstrip(), b"data[1 - 1 :];")
+        self.assertEqual(self._format(b"data[:1-1];").rstrip(), b"data[: 1 - 1];")
+        self.assertEqual(self._format(b"data[   :   ];").rstrip(), b"data[:];")
+
+        # Else surround `:` with spaces.
+        self.assertEqual(self._format(b"data[1-1:1];").rstrip(), b"data[1 - 1 : 1];")
+        self.assertEqual(self._format(b"data[1 :1-1];").rstrip(), b"data[1 : 1 - 1];")
+        self.assertEqual(self._format(b"data[f(): ];").rstrip(), b"data[f() :];")
+
 
 class TestFormattingErrors(unittest.TestCase):
     def _to_bytes(self, content):

--- a/zeekscript/formatter.py
+++ b/zeekscript/formatter.py
@@ -794,11 +794,22 @@ class FormalArgFormatter(Formatter):
 
 class IndexSliceFormatter(Formatter):
     def format(self):
+        # If any of the limits is a compound node and not a literal, constant,
+        # or empty, surround the `:` of the slice with spaces. This mirrors
+        # black's style for Python.
+        use_space_around_colon = any(
+            map(lambda x: len(x.children) > 1, self.node.children)
+        )
+
         self._format_child(hints=Hint.NO_LB_BEFORE)  # '['
+
         while self._get_child_token() != "]":
             self._format_child()
-            if self._get_child_token() != "]":
+
+            # Do not add extra space after end index.
+            if self._get_child_token() != "]" and use_space_around_colon:
                 self._write_sp()
+
         self._format_child(hints=Hint.NO_LB_BEFORE)  # ']'
 
 


### PR DESCRIPTION
We previously would inject extra whitespace around the `:` in an index slice, e.g., `xs[0:1]` would become `xs[0 : 1]`. This is inconsistent with the style e.g., used in Zeek base scripts.

This patch drops the extra spaces around `:`.
