### PR TITLE
Drop unsupported macos-10.15 runner, add macos-12

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15, macos-11]
+        os: [ubuntu-20.04, windows-2019, macos-11, macos-12]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This is all yours @bbannier — I'm going to merge this one real quick so this doesn't keep coming up in other PRs. I will try to get to #49 soon.