### PR TITLE
Add required version to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "zeekscript"
+dynamic = ["version"]
 
 [build-system]
 requires = [ "setuptools", "wheel" ]


### PR DESCRIPTION
This allows installation of this package with Python versions which enforce the pyproject spec.