### PR TITLE
Drop dependency on pytest in default setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ build:
 	python setup.py build
 
 test:
-	pytest
+	cd tests && python -m unittest


### PR DESCRIPTION
We can execute our test suite just fine with built-in tooling, so there was no need to force developers to install `pytest` by default (they can still use it though).