### PR TITLE
Fix file selection of pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,4 +6,4 @@
   entry: zeek-format
   args: [-i] #inplace
   language: python
-  files: '.*zeek'
+  files: \.zeek$


### PR DESCRIPTION
The `files` field expects a regexp, not a shell glob. We'd previously select any file containing `zeek` in its name instead of files ending in `.zeek`.

With this patch we use the intended selection.