### PR TITLE
Fix race in project Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-all: build test
+.PHONY: build test
+
+all: test
 
 build:
 	python setup.py build
 
-test:
+test: build
 	cd tests && python -m unittest


### PR DESCRIPTION
The Makefile did not work correctly when used with `-jN` with $N>1$ since `test` did not declare its dependency on `build`.

This patch makes that dependency explicit, and also declares `build` as PHONY so it is always run.