### PR TITLE
Fix formatting of nodes with no non-error children

### DIFF
--- a/zeekscript/formatter.py
+++ b/zeekscript/formatter.py
@@ -149,6 +149,8 @@ class Formatter:
     def _format_child(self, child=None, indent=False, hints=None):
         if child is None:
             child = self._next_child()
+        if child is None:
+            return
 
         # XXX Pretty subtle that we handle the child's surrounding context here,
         # in the parent. Might have to refactor in the future.


### PR DESCRIPTION
When formatting a `Node`'s child we allowed omitting passing in of the child to format. In that case the user would pass a `None` child and we would attempt to default to formatting the next non-error child. The helper we used to get that child could still return `None` (in case there were only error children remaining, or on incorrect use of the function when the node had no children), but we never handled that case; instead we would have surfaced an `AttributeError` like

```
AttributeError: 'NoneType' object has no attribute 'prev_error_siblings'
```

With this path we explicitly skip any child formatting if we found no child to be formatted.