### PR TITLE
Bump minimum required Python version to 3.10

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
   - id: check-added-large-files
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.3
+  rev: v0.9.2
   hooks:
     - id: ruff
     - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ its [Python bindings](https://github.com/tree-sitter/py-tree-sitter), and our
 
 ## Supported platforms and Python versions
 
-`zeekscript` supports Python 3.7+ on Linux, MacOS, and Windows. We recommend
+`zeekscript` supports Python 3.10+ on Linux, MacOS, and Windows. We recommend
 CPython. PyPy looks prone to crashing on Windows and MacOS, and we're not
 currently building PyPy wheels on those platforms. (We've not investigated PyPy
 in depth and feedback is welcome.)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the package build. See our
 The package comes with a testsuite. To run it, say
 
 ```console
-make
+pytest
 ```
 
 from the toplevel. For details on the tests, take a look at the `tests`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = [
     "parsing",
 ]
 
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 
 dependencies = [
     "tree-sitter==0.23.2",

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -55,9 +55,9 @@ def test_samples(sample: Path, snapshot: SnapshotAssertion):
     name = str(sample.relative_to(SAMPLES_DIR.parent.parent))
 
     output = _format(input_)
-    assert output == snapshot(
-        name=name
-    ), f"formatted {sample} inconsistent with snapshot"
+    assert output == snapshot(name=name), (
+        f"formatted {sample} inconsistent with snapshot"
+    )
 
     output2 = _format(input_)
     assert output2 == output, f"idempotency violation for {sample}"

--- a/zeekscript/cli.py
+++ b/zeekscript/cli.py
@@ -39,8 +39,7 @@ def cmd_format(args):
         if fname == "-":
             if args.inplace:
                 print_error(
-                    "warning: cannot use --inplace when reading from "
-                    "stdin, skipping it"
+                    "warning: cannot use --inplace when reading from stdin, skipping it"
                 )
             else:
                 scripts.append(fname)

--- a/zeekscript/script.py
+++ b/zeekscript/script.py
@@ -39,7 +39,7 @@ class Script:
         parse tree has erroneous nodes.
         """
         try:
-            if isinstance(self.file, (str, pathlib.Path)):
+            if isinstance(self.file, (str | pathlib.Path)):
                 if str(self.file) == "-":
                     # tree-sitter expects bytes, not strings, as input.
                     self.source = sys.stdin.read().encode("UTF-8")


### PR DESCRIPTION
With python-3.9 only receiving security updates some projects have stopped publishing wheels for new releases, e.g., `tree-sitter` requires `python>=3.10` as of 0.24.0 so we cannot build wheels with that version anymore, see https://github.com/zeek/zeekscript/pull/100.

This PR bumps the minimum required Python version to 3.10. This means that we are incompatible with the Python requirements of e.g., https://github.com/zeek/zeek itself which currently requires `python>=3.9`. Since zeekscript is not required to operate Zeek this seems acceptable to me, especially given that python-3.9 will hit EOL 2025-10 so the rest of the Zeek ecosystem might bump its minimum requirement too in the nearer future (i.e., somewhere in the 7.2-8.x timeframe).