### PR TITLE
Bump `tree-sitter-zeek` for better type expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">= 3.10"
 
 dependencies = [
     "tree-sitter==0.24.0",
-    "tree-sitter-zeek==0.2.6",
+    "tree-sitter-zeek==0.2.7",
 ]
 
 [project.optional-dependencies]

--- a/tests/__snapshots__/test_samples/test_samples[expression.zeek].raw
+++ b/tests/__snapshots__/test_samples/test_samples[expression.zeek].raw
@@ -1,0 +1,2 @@
+# Type expressions
+print table[int] of vector of count;

--- a/tests/samples/expression.zeek
+++ b/tests/samples/expression.zeek
@@ -1,0 +1,2 @@
+# Type expressions
+print table  [ int ]   of vector   of    count;


### PR DESCRIPTION
Closes #114 

Just a version bump but with a little explanation: I originally didn't handle it in the other PR since it seemed to me like it'd get handled by formatting. At this point, though, just naming the type expressions as types seems best.

The linked issue has other problems I would *like* to address, but that will be a "breaking" change - I'll submit a proposal PR for those changes and try to get any opinions about changing that behavior.

The offshoot is this is just ending up as a double version bump day :(