### PR TITLE
Enable lints around return statements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
   - id: check-added-large-files
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.3
+  rev: v0.11.7
   hooks:
     - id: ruff
     - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ zeek-script = "zeekscript.cli:zeek_script"
 packages = ["zeekscript"]
 
 [tool.ruff.lint]
-select = ["PL", "UP", "RUF", "N", "I"]
+select = ["PL", "UP", "RUF", "N", "I", "RET"]
 ignore = ["PLR0912", "PLR0915", "PLR2004"]
 
 [tool.ruff.lint.pep8-naming]

--- a/zeekscript/formatter.py
+++ b/zeekscript/formatter.py
@@ -346,8 +346,8 @@ class Formatter:
         """
         if child := self._get_child(offset, absolute):
             return child.type
-        else:
-            return None
+
+        return None
 
     def _get_child_name(self, offset: int = 0, absolute: bool = False) -> str | None:
         """Like _get_child_type(), but for named nodes.
@@ -356,8 +356,8 @@ class Formatter:
         """
         if child := self._get_child(offset, absolute):
             return child.name()
-        else:
-            return None
+
+        return None
 
     def _get_child_token(self, offset: int = 0, absolute: bool = False) -> str | None:
         """Like _get_child_type(), but for terminal nodes.
@@ -367,8 +367,8 @@ class Formatter:
         """
         if child := self._get_child(offset, absolute):
             return child.token()
-        else:
-            return None
+
+        return None
 
     @staticmethod
     def register(symbol_name: str, klass: type[Formatter]) -> None:


### PR DESCRIPTION
This enables a class of return-related lints[^1] around return
statements. I mainly came here for redundant returns after `else`[^2],
but they all seemed useful. In general this seems to reduce nesting, and
also make overall flow clearer.

[^1]: https://docs.astral.sh/ruff/rules/#flake8-return-ret
[^2]: https://docs.astral.sh/ruff/rules/superfluous-else-return/